### PR TITLE
Alternative implementation of `BoundedTreeNursery`: Receive `FragileHandle`s into `FuturesUnordered`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "futures-util",
  "indoc",
  "mime",
+ "pin-project-lite",
  "reqwest",
  "rstest",
  "statrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.5.4", default-features = false, features = ["derive", "err
 futures-util = { version = "0.3.30", default-features = false, features = ["std"] }
 indoc = "2.0.5"
 mime = "0.3.17"
+pin-project-lite = "0.2.14"
 reqwest = "0.12.4"
 statrs = "0.16.0"
 thiserror = "1.0.59"

--- a/src/btn.rs
+++ b/src/btn.rs
@@ -1,9 +1,16 @@
 use futures_util::Stream;
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::Arc;
 use std::task::{ready, Context, Poll};
-use tokio::{sync::Semaphore, task::JoinSet};
+use tokio::{
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        Semaphore,
+    },
+    task::{JoinError, JoinHandle, JoinSet},
+};
 
 /// A task group with the following properties:
 ///
@@ -16,9 +23,11 @@ use tokio::{sync::Semaphore, task::JoinSet};
 ///   (which must all be `T`).
 ///
 /// - Dropping `BoundedTreeNursery` causes all tasks to be aborted.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct BoundedTreeNursery<T> {
-    tasks: Arc<Mutex<JoinSet<T>>>,
+    receiver: UnboundedReceiver<FragileHandle<T>>,
+    tasks: JoinSet<Result<T, JoinError>>,
+    closed: bool,
 }
 
 impl<T: Send + 'static> BoundedTreeNursery<T> {
@@ -30,17 +39,18 @@ impl<T: Send + 'static> BoundedTreeNursery<T> {
         Fut: Future<Output = T> + Send + 'static,
     {
         let semaphore = Arc::new(Semaphore::new(limit));
-        let tasks = Arc::new(Mutex::new(JoinSet::new()));
-        let spawner = Spawner {
-            semaphore,
-            tasks: tasks.clone(),
-        };
+        let (sender, receiver) = unbounded_channel();
+        let spawner = Spawner { semaphore, sender };
         spawner.spawn_with_self(root);
-        BoundedTreeNursery { tasks }
+        BoundedTreeNursery {
+            tasks: JoinSet::new(),
+            receiver,
+            closed: false,
+        }
     }
 }
 
-impl<T: 'static> Stream for BoundedTreeNursery<T> {
+impl<T: Send + 'static> Stream for BoundedTreeNursery<T> {
     type Item = T;
 
     /// Poll for one of the tasks in the group to complete and return its
@@ -49,18 +59,27 @@ impl<T: 'static> Stream for BoundedTreeNursery<T> {
     /// # Panics
     ///
     /// If a task panics, this method resumes unwinding the panic.
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        let mut tasks = self.tasks.lock().unwrap_or_else(PoisonError::into_inner);
-        match ready!(tasks.poll_join_next(cx)) {
-            Some(Ok(r)) => Some(r).into(),
-            Some(Err(e)) => match e.try_into_panic() {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let mut buf = Vec::new();
+        match self.receiver.poll_recv_many(cx, &mut buf, 32) {
+            Poll::Pending => (),
+            Poll::Ready(0) => self.closed = true,
+            Poll::Ready(_) => {
+                for handle in buf {
+                    self.tasks.spawn(handle);
+                }
+            }
+        }
+        match ready!(self.tasks.poll_join_next(cx)) {
+            Some(Ok(Ok(r))) => Some(r).into(),
+            Some(Ok(Err(e)) | Err(e)) => match e.try_into_panic() {
                 Ok(barf) => std::panic::resume_unwind(barf),
                 Err(e) => unreachable!(
                     "Task in BoundedTreeNursery should not have been aborted, but got {e:?}"
                 ),
             },
             None => {
-                if Arc::strong_count(&self.tasks) == 1 {
+                if self.closed {
                     // All spawners dropped and all results yielded; end of
                     // stream
                     None.into()
@@ -76,7 +95,7 @@ impl<T: 'static> Stream for BoundedTreeNursery<T> {
 #[derive(Debug)]
 pub(crate) struct Spawner<T> {
     semaphore: Arc<Semaphore>,
-    tasks: Arc<Mutex<JoinSet<T>>>,
+    sender: UnboundedSender<FragileHandle<T>>,
 }
 
 // Clone can't be derived, as that would erroneously add `T: Clone` bounds to
@@ -85,7 +104,7 @@ impl<T> Clone for Spawner<T> {
     fn clone(&self) -> Spawner<T> {
         Spawner {
             semaphore: self.semaphore.clone(),
-            tasks: self.tasks.clone(),
+            sender: self.sender.clone(),
         }
     }
 }
@@ -107,13 +126,42 @@ impl<T: Send + 'static> Spawner<T> {
         Fut: Future<Output = T> + Send + 'static,
     {
         let semaphore = self.semaphore.clone();
-        let tasks = self.tasks.clone();
-        let mut tasks = tasks.lock().unwrap_or_else(PoisonError::into_inner);
-        tasks.spawn(async move {
+        let sender = self.sender.clone();
+        let _ = sender.send(FragileHandle::new(tokio::spawn(async move {
             let Ok(_permit) = semaphore.acquire().await else {
                 unreachable!("Semaphore should not be closed");
             };
             func(self).await
-        });
+        })));
+    }
+}
+
+pin_project! {
+    /// A wrapper around `tokio::task::JoinHandle` that aborts the task on drop.
+    #[derive(Debug)]
+    struct FragileHandle<T> {
+        #[pin]
+        inner: JoinHandle<T>
+    }
+
+    impl<T> PinnedDrop for FragileHandle<T> {
+        fn drop(this: Pin<&mut Self>) {
+            this.project().inner.abort();
+        }
+    }
+}
+
+impl<T> FragileHandle<T> {
+    fn new(inner: JoinHandle<T>) -> Self {
+        FragileHandle { inner }
+    }
+}
+
+impl<T> Future for FragileHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.inner.poll(cx)
     }
 }


### PR DESCRIPTION
Based on suggestions at <https://users.rust-lang.org/t/110615/>.