### PR TITLE
Alternative implementation of `BoundedTreeNursery`: Send results from tasks with cancellation tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "statrs",
  "thiserror",
  "tokio",
+ "tokio-util",
  "url",
  "winnow",
  "xml-rs",
@@ -1290,16 +1291,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = "0.12.4"
 statrs = "0.16.0"
 thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tokio-util = { version = "0.7.11", default-features = false }
 url = "2.5.0"
 winnow = "0.6.7"
 xml-rs = "0.8.20"

--- a/src/btn.rs
+++ b/src/btn.rs
@@ -38,17 +38,16 @@ impl<T: Send + 'static> BoundedTreeNursery<T> {
     {
         let semaphore = Arc::new(Semaphore::new(limit));
         let token = CancellationToken::new();
-        let on_drop = token.clone().drop_guard();
         let (sender, receiver) = unbounded_channel();
         let spawner = Spawner {
             semaphore,
             sender,
-            token,
+            token: token.child_token(),
         };
         spawner.spawn_with_self(root);
         BoundedTreeNursery {
             receiver,
-            _on_drop: on_drop,
+            _on_drop: token.drop_guard(),
         }
     }
 }


### PR DESCRIPTION
Based on https://users.rust-lang.org/t/110933/2.